### PR TITLE
Add pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,28 @@
+default_install_hook_types: [pre-commit, commit-msg]
+default_stages: [pre-commit]
+exclude: ^assets/
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v1.2.3
+    hooks:
+      - id: check-added-large-files
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
+  # spell check
+  - repo: https://github.com/codespell-project/codespell
+    rev: v2.2.4
+    hooks:
+      - id: codespell
+        # https://github.com/codespell-project/codespell/issues/1498
+  # general linting
+  - repo: https://github.com/pre-commit/mirrors-prettier
+    rev: v2.7.1
+    hooks:
+      - id: prettier
+  # enforce commit format
+  - repo: https://github.com/compilerla/conventional-pre-commit
+    rev: v2.3.0
+    hooks:
+      - id: conventional-pre-commit
+        stages: [commit-msg]
+        args: []

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,4 @@
+overrides:
+  - files: "*.md"
+    options:
+      tabWidth: 2


### PR DESCRIPTION
Adds relevant pre-commit hooks from our nextflow template, including:

- lint and style files
- run spellcheck
- fix trailing whitespace