### PR TITLE
Improve reusable workflow instructions for other organizations

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -31,6 +31,12 @@
 
 If your repo is not part of the CCBR GitHub organization, you will need to do a few additional steps.
 
+1. [Create a token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#creating-a-personal-access-token-classic) with repo & project scope.
+
+1. [Add the token to your organization as a secret](https://docs.github.com/en/codespaces/managing-codespaces-for-your-organization/managing-secrets-for-your-repository-and-organization-for-github-codespaces#adding-secrets-for-an-organization) and name it `ADD_TO_PROJECT_PAT`.
+
+    Alternatively, if you don't have the permissions to add a secret to your organization, you can [add the secret to your repo](https://docs.github.com/en/actions/security-guides/using-secrets-in-github-actions#creating-secrets-for-a-repository).
+
 1. Create a YAML file following [this format](https://github.com/CCBR/.github/blob/main/assets/user-kanbans.yml) to map usernames of organization members to their project boards.
    We recommend keeping this file in a central public repo, such as `YOUR_ORG/.github`.
 
@@ -52,22 +58,10 @@ If your repo is not part of the CCBR GitHub organization, you will need to do a 
         uses: CCBR/.github/.github/workflows/auto-add-user-project.yml@main
         with:
           user_projects: https://raw.githubusercontent.com/YOUR_ORG/.github/main/assets/user-kanbans.yml
-        secrets: inherit
+        secrets:
+          ADD_TO_PROJECT_PAT: ${{ secrets.ADD_TO_PROJECT_PAT }}
     ```
 
     Be sure to replace the `user_projects` URL with the actual URL to your YAML file of usernames & their project boards.
 
-1. [Create a token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#creating-a-personal-access-token-classic) with repo & project scope.
-
-1. [Add the token to your organization as a secret](https://docs.github.com/en/codespaces/managing-codespaces-for-your-organization/managing-secrets-for-your-repository-and-organization-for-github-codespaces#adding-secrets-for-an-organization) and name it `ADD_TO_PROJECT_PAT`.
-
-    Alternatively, if you don't have the permissions to add a secret to your organization, you can [add the secret to your repo](https://docs.github.com/en/actions/security-guides/using-secrets-in-github-actions#creating-secrets-for-a-repository) and pass it to the action with:
-
-    ```yaml
-    uses: CCBR/.github/.github/workflows/auto-add-user-project.yml@main
-    with:
-      user_projects: https://raw.githubusercontent.com/YOUR_ORG/.github/main/assets/user-kanbans.yml
-    secrets:
-      ADD_TO_PROJECT_PAT: ${{ secrets.ADD_TO_PROJECT_PAT }}
-    ```
 

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -12,12 +12,12 @@
     name: Add issues/PRs to user projects
 
     on:
-    issues:
-      types:
-      - assigned
-    pull_request:
-      types:
-      - assigned
+      issues:
+        types:
+        - assigned
+      pull_request:
+        types:
+        - assigned
 
     jobs:
       add-to-project:
@@ -46,12 +46,12 @@ If your repo is not part of the CCBR GitHub organization, you will need to do a 
     name: Add issues/PRs to user projects
 
     on:
-    issues:
-      types:
-      - assigned
-    pull_request:
-      types:
-      - assigned
+      issues:
+        types:
+        - assigned
+      pull_request:
+        types:
+        - assigned
 
     jobs:
       add-to-project:

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -6,7 +6,7 @@
 
 1. Add your username and GitHub project URL to the organization-wide list of project boards in [`assets/user-kanbans.yml`](https://github.com/CCBR/.github/blob/main/assets/user-kanbans.yml) if it's not already listed.
 
-1. In your repo where issues and PRs will be opened, create a YAML file in `.github/workflows` with the following content:
+1. In your repo where issues and PRs will be opened, create a workflow YAML file in `.github/workflows` with the following content:
 
     ```yaml
     name: Add issues/PRs to user projects
@@ -34,7 +34,7 @@ If your repo is not part of the CCBR GitHub organization, you will need to do a 
 1. Create a YAML file following [this format](https://github.com/CCBR/.github/blob/main/assets/user-kanbans.yml) to map usernames of organization members to their project boards.
    We recommend keeping this file in a central public repo, such as `YOUR_ORG/.github`.
 
-1. In any repo where issues and PRs will be opened, create a YAML file in `.github/workflows` with the following content:
+1. In any repo where issues and PRs will be opened, create a workflow YAML file in `.github/workflows` with the following content:
 
     ```yaml
     name: Add issues/PRs to user projects
@@ -55,7 +55,7 @@ If your repo is not part of the CCBR GitHub organization, you will need to do a 
           secrets: inherit
     ```
 
-    Be sure to replace the `user_projects` URL with the actual URL to your YAML file.
+    Be sure to replace the `user_projects` URL with the actual URL to your YAML file of usernames & their project boards.
 
 1. Create a token with repo & project scope.
 

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -2,27 +2,72 @@
 
 ## Auto-add issues & PRs to user projects
 
-1. Add your username and GitHub project URL to the organization-wide list of kanbans in [`assets/user-kanbans.yml`](https://github.com/CCBR/.github/blob/main/assets/user-kanbans.yml).
+### within CCBR
 
-1. In your repo, create a YAML file in `.github/workflows` with the following content:
+1. Add your username and GitHub project URL to the organization-wide list of project boards in [`assets/user-kanbans.yml`](https://github.com/CCBR/.github/blob/main/assets/user-kanbans.yml) if it's not already listed.
+
+1. In your repo where issues and PRs will be opened, create a YAML file in `.github/workflows` with the following content:
 
     ```yaml
     name: Add issues/PRs to user projects
 
     on:
     issues:
-        types:
-        - assigned
+      types:
+      - assigned
     pull_request:
-        types:
-        - assigned
+      types:
+      - assigned
 
     jobs:
-    add-to-project:
+      add-to-project:
         uses: CCBR/.github/.github/workflows/auto-add-user-project.yml@main
-        with:
-        username: ${{ github.event.assignee.login }}
-        secrets: inherit
+          secrets: inherit
     ```
 
-1. Every time an issue or PR in the repo is assigned to you, it will be added to your project kanban.
+1. Every time an issue or PR in the repo is assigned to a user listed in [`assets/user-kanbans.yml`](https://github.com/CCBR/.github/blob/main/assets/user-kanbans.yml), it will be added to their project board.
+
+### other organizations
+
+If your repo is not part of the CCBR GitHub organization, you will need to do a few additional steps.
+
+1. Create a YAML file following [this format](https://github.com/CCBR/.github/blob/main/assets/user-kanbans.yml) to map usernames of organization members to their project boards.
+   We recommend keeping this file in a central public repo, such as `YOUR_ORG/.github`.
+
+1. In any repo where issues and PRs will be opened, create a YAML file in `.github/workflows` with the following content:
+
+    ```yaml
+    name: Add issues/PRs to user projects
+
+    on:
+    issues:
+      types:
+      - assigned
+    pull_request:
+      types:
+      - assigned
+
+    jobs:
+      add-to-project:
+          uses: CCBR/.github/.github/workflows/auto-add-user-project.yml@main
+          with:
+            user_projects: https://raw.githubusercontent.com/YOUR_ORG/.github/main/assets/user-kanbans.yml
+          secrets: inherit
+    ```
+
+    Be sure to replace the `user_projects` URL with the actual URL to your YAML file.
+
+1. Create a token with repo & project scope.
+
+1. [Add the token to your organization as a secret](https://docs.github.com/en/codespaces/managing-codespaces-for-your-organization/managing-secrets-for-your-repository-and-organization-for-github-codespaces#adding-secrets-for-an-organization) and name it `ADD_TO_PROJECT_PAT`.
+
+    Alternatively, if you don't have the permissions to add a secret to your organization, you can add it to your repo and pass it to the action with:
+
+    ```yaml
+    uses: CCBR/.github/.github/workflows/auto-add-user-project.yml@main
+      with:
+        user_projects: https://raw.githubusercontent.com/YOUR_ORG/.github/main/assets/user-kanbans.yml
+      secrets:
+        ADD_TO_PROJECT_PAT: ${{ secrets.ADD_TO_PROJECT_PAT }}
+    ```
+

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -57,7 +57,7 @@ If your repo is not part of the CCBR GitHub organization, you will need to do a 
 
     Be sure to replace the `user_projects` URL with the actual URL to your YAML file of usernames & their project boards.
 
-1. Create a token with repo & project scope.
+1. [Create a token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#creating-a-personal-access-token-classic) with repo & project scope.
 
 1. [Add the token to your organization as a secret](https://docs.github.com/en/codespaces/managing-codespaces-for-your-organization/managing-secrets-for-your-repository-and-organization-for-github-codespaces#adding-secrets-for-an-organization) and name it `ADD_TO_PROJECT_PAT`.
 

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -61,7 +61,7 @@ If your repo is not part of the CCBR GitHub organization, you will need to do a 
 
 1. [Add the token to your organization as a secret](https://docs.github.com/en/codespaces/managing-codespaces-for-your-organization/managing-secrets-for-your-repository-and-organization-for-github-codespaces#adding-secrets-for-an-organization) and name it `ADD_TO_PROJECT_PAT`.
 
-    Alternatively, if you don't have the permissions to add a secret to your organization, you can add it to your repo and pass it to the action with:
+    Alternatively, if you don't have the permissions to add a secret to your organization, you can [add the secret to your repo](https://docs.github.com/en/actions/security-guides/using-secrets-in-github-actions#creating-secrets-for-a-repository) and pass it to the action with:
 
     ```yaml
     uses: CCBR/.github/.github/workflows/auto-add-user-project.yml@main

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -49,10 +49,10 @@ If your repo is not part of the CCBR GitHub organization, you will need to do a 
 
     jobs:
       add-to-project:
-          uses: CCBR/.github/.github/workflows/auto-add-user-project.yml@main
-          with:
-            user_projects: https://raw.githubusercontent.com/YOUR_ORG/.github/main/assets/user-kanbans.yml
-          secrets: inherit
+        uses: CCBR/.github/.github/workflows/auto-add-user-project.yml@main
+        with:
+          user_projects: https://raw.githubusercontent.com/YOUR_ORG/.github/main/assets/user-kanbans.yml
+        secrets: inherit
     ```
 
     Be sure to replace the `user_projects` URL with the actual URL to your YAML file of usernames & their project boards.

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -22,7 +22,7 @@
     jobs:
       add-to-project:
         uses: CCBR/.github/.github/workflows/auto-add-user-project.yml@main
-          secrets: inherit
+        secrets: inherit
     ```
 
 1. Every time an issue or PR in the repo is assigned to a user listed in [`assets/user-kanbans.yml`](https://github.com/CCBR/.github/blob/main/assets/user-kanbans.yml), it will be added to their project board.
@@ -65,9 +65,9 @@ If your repo is not part of the CCBR GitHub organization, you will need to do a 
 
     ```yaml
     uses: CCBR/.github/.github/workflows/auto-add-user-project.yml@main
-      with:
-        user_projects: https://raw.githubusercontent.com/YOUR_ORG/.github/main/assets/user-kanbans.yml
-      secrets:
-        ADD_TO_PROJECT_PAT: ${{ secrets.ADD_TO_PROJECT_PAT }}
+    with:
+      user_projects: https://raw.githubusercontent.com/YOUR_ORG/.github/main/assets/user-kanbans.yml
+    secrets:
+      ADD_TO_PROJECT_PAT: ${{ secrets.ADD_TO_PROJECT_PAT }}
     ```
 

--- a/.github/workflows/auto-add-user-project.yml
+++ b/.github/workflows/auto-add-user-project.yml
@@ -6,7 +6,7 @@ on:
       username:
         required: false
         type: string
-        description: "GitHub username of person assigned to the Issue or PR"
+        description: "GitHub username of the person assigned to the Issue or PR"
         default: ${{ github.event.assignee.login }}
       user_projects:
         required: false

--- a/.github/workflows/auto-add-user-project.yml
+++ b/.github/workflows/auto-add-user-project.yml
@@ -4,8 +4,15 @@ on:
   workflow_call:
     inputs:
       username:
-        required: true
+        required: false
         type: string
+        description: "GitHub username of person assigned to the Issue or PR"
+        default: ${{ github.event.assignee.login }}
+      user_projects:
+        required: false
+        type: string
+        description: "URL of a yaml file mapping usernames to project boards"
+        default: https://raw.githubusercontent.com/CCBR/.github/main/assets/user-kanbans.yml
     secrets:
       ADD_TO_PROJECT_PAT:
         required: true
@@ -16,7 +23,7 @@ jobs:
     steps:
       - name: download yaml
         run: |
-          wget https://raw.githubusercontent.com/CCBR/.github/main/assets/user-kanbans.yml
+          wget ${{ inputs.user_projects }}
 
       - uses: pietrobolcato/action-read-yaml@1.1.0
         id: metadata


### PR DESCRIPTION
- Modified the add-to-user-projects workflow to:
  - Optionally accept a different URL for user projects.
  - Use the calling workflow's context to get the assignee username by default.
- Added instructions to the README for members of other organizations.