### PR TITLE
fix: run reponame_labels.yaml only when issue opened

### DIFF
--- a/.github/workflows/reponame_labels.yaml
+++ b/.github/workflows/reponame_labels.yaml
@@ -2,7 +2,9 @@ name: Auto add reponame as label to all issues and PRs
 
 on:
   issues:
+    - opened
   pull_request:
+    - opened
 
 jobs:
   add_label:


### PR DESCRIPTION
otherwise, it runs the workflow every time there's _any_ activity on the issue, e.g. see https://github.com/CCBR/TRANQUIL/pull/5