### PR TITLE
Sync public forks for NCIPangea

### DIFF
--- a/.github/workflows/sync-forks.yml
+++ b/.github/workflows/sync-forks.yml
@@ -3,7 +3,6 @@ name: Sync Forks
 on:
   schedule:
     - cron: "47 11 * * *" # once every day
-  workflow_dispatch: # on button click
   push:
     paths:
       - .github/workflows/sync-forks.yml

--- a/.github/workflows/sync-forks.yml
+++ b/.github/workflows/sync-forks.yml
@@ -12,7 +12,8 @@ permissions:
   contents: write
 
 env:
-  # token must be created by someone with write access for all forks
+  # Token must be created by someone with write access for all forks.
+  # Be sure to 'configure SSO' from the token creation page for each fork organization.
   GH_TOKEN: ${{ secrets.SYNC_FORK_TOKEN }}
   UPSTREAM_OWNER: CCBR
 

--- a/.github/workflows/sync-forks.yml
+++ b/.github/workflows/sync-forks.yml
@@ -1,0 +1,29 @@
+name: Sync Forks
+
+on:
+  schedule:
+    - cron: "47 11 * * *" # once every day
+  workflow_dispatch: # on button click
+  push:
+    paths:
+      - .github/workflows/sync-forks.yml
+
+permissions:
+  contents: write
+
+env:
+  # token must be created by someone with write access for all forks
+  GH_TOKEN: ${{ secrets.SYNC_FORK_TOKEN }}
+  UPSTREAM_OWNER: CCBR
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        FORK_OWNER: [NCIPangea]
+        REPO: [XAVIER, RENEE]
+    steps:
+      - name: sync forked repos
+        run: |
+          gh repo sync ${{ matrix.FORK_OWNER }}/${{ matrix.REPO }} --source $UPSTREAM_OWNER/${{ matrix.REPO }} --force


### PR DESCRIPTION
A new action to supersede the individual sync-fork actions we have in place for [XAVIER](https://github.com/CCBR/XAVIER/blob/d1c527b769fcfd68c232477a2f37d3a371419681/.github/workflows/sync-fork.yml) and [RENEE](https://github.com/CCBR/RENEE/blob/10ae5e167ae09f08440af39a9bb869085c3c3591/.github/workflows/sync-fork.yml). This uses a matrix to run `gh repo sync` on all public forks we specify in this workflow's matrix.

~@kopardev: I think you will need to go into this repo's settings and update the `SYNC_FORK_TOKEN` secret with a new token with repo & workflow scopes. This token will need to be configured to work for CCBR, NCIPangea, and any other organizations that will have forks synced automatically. I don't think my token will work for NCIPangea because the option didn't come up when I tried to configure SSO after creating the token.~ _Edit: actually it looks like my token worked for NCIPangea! I'm unsure if it'll work for the ABCS org, but we can cross that bridge when we get there. I believe the creator of the token must have write access to all forks for it to work._

Resolves https://github.com/CCBR/kelly_log/issues/16