### PR TITLE
ci: update runners to use ubuntu-latest

### DIFF
--- a/.github/workflows/auto_update_org_readme.yml
+++ b/.github/workflows/auto_update_org_readme.yml
@@ -1,14 +1,13 @@
 name: Auto update CCBR README
 
-
 on:
   workflow_dispatch:
   schedule:
-    - cron: '30 04 * * 0'
+    - cron: "30 04 * * 0"
 
 jobs:
   createreadme:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       # Step 1: Checkout the main repository
       - name: Checkout repo
@@ -28,7 +27,7 @@ jobs:
       # Step 4: Run Docker to generate the README file
       - name: Run Docker to make readme
         env:
-            GITHUB_TOKEN: ${{ secrets.OMNITOKEN }}
+          GITHUB_TOKEN: ${{ secrets.OMNITOKEN }}
         run: |
           docker run -e GITHUB_TOKEN=$GITHUB_TOKEN -v ${{ github.workspace }}:/workspace -w /workspace nciccbr/make_readme:latest bash ./assets/make_readme/make_readme.sh
 
@@ -51,9 +50,8 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: CCBR/ccbr.github.io
-          token: ${{ secrets.OMNITOKEN }}  # Personal Access Token (PAT)
+          token: ${{ secrets.OMNITOKEN }} # Personal Access Token (PAT)
           path: ccbr.github.io
-
 
       # Step 8: Copy the generated README.md to the index.md of the GitHub Pages repo
       - name: Copy README.md to index.md


### PR DESCRIPTION
gh is deprecating ubuntu-20.04