### PR TITLE
ci: use gh app to generate token rather than classic token

### DIFF
--- a/.github/workflows/sync-forks.yml
+++ b/.github/workflows/sync-forks.yml
@@ -39,7 +39,6 @@ jobs:
           - l2p
           - METRO
           - MAAPSTER
-          - permfix
           - pyrkit
           - rNA
           - SINCLAIR


### PR DESCRIPTION
## Changes

Switch from using a classic token for gh authentication to generating one with the CCBR-bot app.

@kopardev can you install the CCBR-bot and set the app ID variable and private key secret for each of these organizations? instructions here: https://ccbr.github.io/actions/gh-app-auth.html

- abcsFrederick
- CCRGeneticsBranch
- NCIPangea
- NCI-CCR-POB
- NCI-CCDI
- NCI-RBL

## Issues

see also https://github.com/NCI-RBL/.github/pull/1

## PR Checklist

(~Strikethrough~ any points that are not applicable.)

- [x] This comment contains a description of changes with justifications, with any relevant issues linked.
- ~[ ] Write unit tests for any new features, bug fixes, or other code changes.~
- ~[ ] Update docs if there are any API changes.~
- ~[ ] Update `CHANGELOG.md` with a short description of any user-facing changes and reference the PR number. Guidelines: https://keepachangelog.com/en/1.1.0/~
